### PR TITLE
fix(AnimateIcon): forward class/style to inner svg when icon self-wraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+- **`class` and `style` now reach the inner `<motion.svg>` when an icon
+  self-wraps.** Previously, setting any trigger (`animate`, `animateOnHover`,
+  `animateOnTap`, `animateOnView`) made the icon render as
+  `<AnimateIcon><Icon /></AnimateIcon>`, and Vue's default attribute
+  fallthrough sent the consumer's `class`/`style` to `AnimateIcon`'s `<span>`
+  wrapper instead of the SVG. CSS-based sizing (`<Heart class="w-6 h-6"
+  animateOnHover />`, the idiom `lucide-vue-next` users carry over) silently
+  broke. `<AnimateIcon>` is now `inheritAttrs: false` and forwards fallthrough
+  attrs (class, style, events, aria, data-*) onto the slot's first vnode via
+  `cloneVNode`. No icon-SFC changes; the static path (`<Heart class="w-6
+  h-6" />` without triggers) was already correct and is unaffected.
 
 ## [0.4.0] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   - [Per-icon subpath imports](#per-icon-subpath-imports)
 - [Nuxt module](#nuxt-module)
 - [Props](#props)
-- [Color](#color)
+- [Styling](#styling)
 - [`<AnimateIcon>` wrapper](#animateicon-wrapper)
 - [Discovering variants (`iconsMeta`)](#discovering-variants-iconsmeta)
 - [TypeScript](#typescript)
@@ -172,7 +172,7 @@ Off by default because other icons (e.g. `link-2`'s burst particles) are designe
 
 Icons that are conceptually infinite (`LoaderCircle`, `Loader`, `LoaderPinwheel`, etc.) bake `repeat: Infinity` into their own variant transitions, so they loop as soon as you trigger them — no prop required. One-shot icons play once per trigger.
 
-## Color
+## Styling
 
 Icons use `stroke="currentColor"` (and `fill: 'currentColor'` for fill-based variants), so color is driven by the parent's CSS `color` — same pattern as `lucide-vue-next`. Fill-based animations automatically pick up whatever color you set, so the tween stays on-brand.
 
@@ -181,6 +181,14 @@ Icons use `stroke="currentColor"` (and `fill: 'currentColor'` for fill-based var
 <Heart animateOnHover class="text-rose-500" />
 <Heart animateOnHover animation="fill" style="color: #4f46e5" />
 <div style="color: var(--my-brand)"><Heart animateOnHover /></div>
+```
+
+Width and height can come from the `size` prop *or* CSS. Utility classes (`w-6 h-6`, `size-8`), scoped styles, and inline `style` all land on the inner `<svg>` — whether the icon self-wraps (any trigger prop set) or not.
+
+```vue
+<Heart :size="40" />
+<Heart animateOnHover class="w-10 h-10" />
+<Heart animateOnHover style="width: 40px; height: 40px" />
 ```
 
 ## `<AnimateIcon>` wrapper

--- a/docs/sections/StylingSection.vue
+++ b/docs/sections/StylingSection.vue
@@ -10,11 +10,16 @@ const snippet = `<!-- Any of these work, including fill animations -->
 <div style="color: var(--my-brand)">
   <Heart animateOnHover />
 </div>`
+
+const sizingSnippet = `<!-- size prop, utility classes, and inline style all work -->
+<Heart :size="40" />
+<Heart animateOnHover class="w-10 h-10" />
+<Heart animateOnHover style="width: 40px; height: 40px" />`
 </script>
 
 <template>
-  <section class="doc-section" id="color">
-    <h2>Color</h2>
+  <section class="doc-section" id="styling">
+    <h2>Styling</h2>
     <p>
       Icons use <code>stroke="currentColor"</code> and, for fill-based
       variants, <code>fill: 'currentColor'</code>. That means color is driven
@@ -37,11 +42,21 @@ const snippet = `<!-- Any of these work, including fill animations -->
       <CodeBlock :code="snippet" lang="vue" />
     </div>
 
+    <h3>Sizing via CSS</h3>
+    <p>
+      Width and height can come from the <code>size</code> prop <em>or</em>
+      CSS. Utility classes (<code>w-6 h-6</code>), scoped styles, and inline
+      <code>style</code> all land on the inner <code>&lt;svg&gt;</code> —
+      whether the icon self-wraps (any trigger prop set) or not.
+    </p>
+    <CodeBlock :code="sizingSnippet" lang="vue" />
+
     <h3>Tailwind</h3>
     <p>
       Any utility that sets <code>color</code> works —
       <code>text-rose-500</code>, <code>text-primary</code>,
-      <code>dark:text-slate-100</code>, etc.
+      <code>dark:text-slate-100</code>, etc. The same goes for sizing
+      (<code>w-6 h-6</code>, <code>size-8</code>) and arbitrary properties.
     </p>
 
     <h3>Fill variants</h3>

--- a/docs/sections/sections.ts
+++ b/docs/sections/sections.ts
@@ -9,7 +9,7 @@ export const sections: DocSection[] = [
   { slug: 'props',         title: 'Props',             blurb: 'Every prop on every icon, with a live playground.' },
   { slug: 'buttons',       title: 'Icons in buttons',  blurb: 'Make the whole button the trigger.' },
   { slug: 'variants',      title: 'Variants',          blurb: 'Switch between named animations.' },
-  { slug: 'color',         title: 'Color',             blurb: 'Drive icon color from the surrounding text color.' },
+  { slug: 'styling',       title: 'Styling',           blurb: 'Drive color and size via currentColor and CSS — class, style, size prop.' },
   { slug: 'programmatic',  title: 'Programmatic',      blurb: 'Trigger animations from your own state.' },
   { slug: 'typescript',    title: 'TypeScript',        blurb: 'Typed props, wrapper helpers, metadata shape.' },
   { slug: 'accessibility', title: 'Accessibility',     blurb: 'Labels, reduced motion, static fallbacks.' },

--- a/docs/views/DocsView.vue
+++ b/docs/views/DocsView.vue
@@ -5,7 +5,7 @@ import QuickstartSection from '../sections/QuickstartSection.vue'
 import PropsSection from '../sections/PropsSection.vue'
 import ButtonsSection from '../sections/ButtonsSection.vue'
 import VariantsSection from '../sections/VariantsSection.vue'
-import ColorSection from '../sections/ColorSection.vue'
+import StylingSection from '../sections/StylingSection.vue'
 import ProgrammaticSection from '../sections/ProgrammaticSection.vue'
 import TypescriptSection from '../sections/TypescriptSection.vue'
 import AccessibilitySection from '../sections/AccessibilitySection.vue'
@@ -136,7 +136,7 @@ onBeforeUnmount(() => {
       <PropsSection />
       <ButtonsSection />
       <VariantsSection />
-      <ColorSection />
+      <StylingSection />
       <ProgrammaticSection />
       <TypescriptSection />
       <AccessibilitySection />

--- a/playground/App.vue
+++ b/playground/App.vue
@@ -19,6 +19,18 @@ const playing = ref(false)
         </v-card>
 
         <v-card class="pa-6 mb-4">
+          <h2 class="text-h6 mb-3">
+            1a. CSS-sized icon (class wins — <code>:size</code> unset)
+          </h2>
+          <p class="text-caption mb-2">
+            Both icons should render at 72×72. The animated one self-wraps via
+            <code>animateOnHover</code>; the class must still reach the svg.
+          </p>
+          <BetweenVerticalStart class="icon-lg" />
+          <Heart animateOnHover class="icon-lg ml-4" style="color: crimson" />
+        </v-card>
+
+        <v-card class="pa-6 mb-4">
           <h2 class="text-h6 mb-3">2. Self-wrapped: <code>animateOnTap</code></h2>
           <BetweenVerticalStart animateOnTap :size="48" />
         </v-card>
@@ -73,3 +85,16 @@ const playing = ref(false)
     </v-main>
   </v-app>
 </template>
+
+<style>
+/*
+  Not scoped on purpose — scoped selectors only attach `data-v-*` to a child
+  component's root, so with a self-wrapped icon they'd match the span wrapper
+  but not the inner svg. Global rules mirror how consumers ship utility CSS
+  (Tailwind, a global app.css, etc.).
+*/
+.icon-lg {
+  width: 72px;
+  height: 72px;
+}
+</style>

--- a/src/core/AnimateIcon.vue
+++ b/src/core/AnimateIcon.vue
@@ -3,7 +3,6 @@ import {
   cloneVNode,
   Comment,
   computed,
-  defineComponent,
   onBeforeUnmount,
   onMounted,
   provide,
@@ -12,6 +11,7 @@ import {
   useAttrs,
   useSlots,
   watch,
+  type VNode,
 } from 'vue'
 import { useInView } from 'motion-v'
 import {
@@ -21,11 +21,7 @@ import {
   type VariantName,
 } from './context'
 
-// Fallthrough attrs (especially `class` and `style`) are forwarded onto the
-// first vnode of the default slot rather than onto our <span> wrapper — see
-// `ForwardedSlot` below. Without this opt-out, Vue's default inheritance
-// sends `<Heart class="w-6 h-6" animateOnHover />` to the span instead of the
-// inner <motion.svg>, silently breaking CSS-based sizing.
+// See `ForwardedSlot` below for why fallthrough is opted out.
 defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(
@@ -143,7 +139,7 @@ defineExpose({ on })
 // slot. Icons that self-wrap (any trigger prop set) render
 // `<AnimateIcon><Icon /></AnimateIcon>`, so without this the user's `class`
 // and `style` would land on the span wrapper instead of the inner
-// <motion.svg>. That silently breaks the lucide-vue-next idiom of sizing via
+// <motion.svg> — silently breaking the lucide-vue-next idiom of sizing via
 // CSS utility classes (`w-6 h-6`, `.icon { width: 1em }`). We also forward
 // events / aria / id / data-* so `@click`, `aria-label`, etc. continue to
 // work — they would otherwise be dropped entirely under inheritAttrs:false.
@@ -151,29 +147,22 @@ defineExpose({ on })
 // bindings on the slotted vnode win.
 const attrs = useAttrs()
 const slots = useSlots()
-const ForwardedSlot = defineComponent({
-  name: 'AnimateIconForwardedSlot',
-  inheritAttrs: false,
-  setup() {
-    return () => {
-      const nodes = slots.default?.() ?? []
-      const keys = Object.keys(attrs)
-      if (keys.length === 0) return nodes
-      const out: any[] = []
-      let forwarded = false
-      for (const n of nodes as any[]) {
-        const renderable = n && n.type !== Comment && n.type !== Text
-        if (!forwarded && renderable) {
-          out.push(cloneVNode(n, attrs))
-          forwarded = true
-        } else {
-          out.push(n)
-        }
-      }
-      return out
+function ForwardedSlot(): VNode[] {
+  const nodes = (slots.default?.() ?? []) as VNode[]
+  if (Object.keys(attrs).length === 0) return nodes
+  const out: VNode[] = []
+  let forwarded = false
+  for (const n of nodes) {
+    const renderable = n && n.type !== Comment && n.type !== Text
+    if (!forwarded && renderable) {
+      out.push(cloneVNode(n, attrs))
+      forwarded = true
+    } else {
+      out.push(n)
     }
-  },
-})
+  }
+  return out
+}
 
 // When `triggerTarget !== 'self'`, hand listener duty off to the resolved
 // ancestor element. We must *also* drop them from the span, otherwise moving

--- a/src/core/AnimateIcon.vue
+++ b/src/core/AnimateIcon.vue
@@ -1,5 +1,18 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue'
+import {
+  cloneVNode,
+  Comment,
+  computed,
+  defineComponent,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  ref,
+  Text,
+  useAttrs,
+  useSlots,
+  watch,
+} from 'vue'
 import { useInView } from 'motion-v'
 import {
   AnimateIconKey,
@@ -7,6 +20,13 @@ import {
   type TriggerTarget,
   type VariantName,
 } from './context'
+
+// Fallthrough attrs (especially `class` and `style`) are forwarded onto the
+// first vnode of the default slot rather than onto our <span> wrapper — see
+// `ForwardedSlot` below. Without this opt-out, Vue's default inheritance
+// sends `<Heart class="w-6 h-6" animateOnHover />` to the span instead of the
+// inner <motion.svg>, silently breaking CSS-based sizing.
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(
   defineProps<{
@@ -119,6 +139,42 @@ const on = {
 }
 defineExpose({ on })
 
+// Forward fallthrough attrs onto the first element-like vnode of our default
+// slot. Icons that self-wrap (any trigger prop set) render
+// `<AnimateIcon><Icon /></AnimateIcon>`, so without this the user's `class`
+// and `style` would land on the span wrapper instead of the inner
+// <motion.svg>. That silently breaks the lucide-vue-next idiom of sizing via
+// CSS utility classes (`w-6 h-6`, `.icon { width: 1em }`). We also forward
+// events / aria / id / data-* so `@click`, `aria-label`, etc. continue to
+// work — they would otherwise be dropped entirely under inheritAttrs:false.
+// cloneVNode merges class and style rather than overwriting, so explicit
+// bindings on the slotted vnode win.
+const attrs = useAttrs()
+const slots = useSlots()
+const ForwardedSlot = defineComponent({
+  name: 'AnimateIconForwardedSlot',
+  inheritAttrs: false,
+  setup() {
+    return () => {
+      const nodes = slots.default?.() ?? []
+      const keys = Object.keys(attrs)
+      if (keys.length === 0) return nodes
+      const out: any[] = []
+      let forwarded = false
+      for (const n of nodes as any[]) {
+        const renderable = n && n.type !== Comment && n.type !== Text
+        if (!forwarded && renderable) {
+          out.push(cloneVNode(n, attrs))
+          forwarded = true
+        } else {
+          out.push(n)
+        }
+      }
+      return out
+    }
+  },
+})
+
 // When `triggerTarget !== 'self'`, hand listener duty off to the resolved
 // ancestor element. We must *also* drop them from the span, otherwise moving
 // between button → icon fires both and `start()` re-resets `current` mid-
@@ -198,6 +254,6 @@ defineSlots<{
     }"
     v-on="selfListeners"
   >
-    <slot />
+    <ForwardedSlot />
   </span>
 </template>


### PR DESCRIPTION
## Summary

- When an icon self-wraps (`animate`, `animateOnHover`, `animateOnTap`, `animateOnView`), Vue's default attribute inheritance routed the consumer's `class` / `style` to `<AnimateIcon>`'s `<span>` wrapper instead of the inner `<motion.svg>`. CSS-based sizing — `<Heart class="w-6 h-6" animateOnHover />`, the idiom carried over from `lucide-vue-next` — silently broke.
- `<AnimateIcon>` is now `inheritAttrs: false` and forwards fallthrough attrs (class, style, events, aria-*, data-*) onto the slot's first vnode via `cloneVNode`. `cloneVNode`'s merge semantics keep class/style non-destructive, so explicit bindings on the slotted vnode still win.
- No icon-SFC changes — the static path (no triggers) was already correct and is unaffected. The fix is centralized in `src/core/AnimateIcon.vue`.

## Repro

```vue
<!-- Before: renders at the default 28×28 when animateOnHover is set. -->
<!-- After:  renders at 72×72 as expected.                            -->
<Heart animateOnHover class="icon-lg" />

<style>
.icon-lg { width: 72px; height: 72px; }
</style>
```

A persistent smoke-test card (`1a. CSS-sized icon`) was added to `playground/App.vue` — same icon with and without a trigger, both must size to 72×72.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] Playground card 1a: both icons render at 72×72; class lands on the `<svg>`, not the `<span>`
- [x] Card 1 regression check: `style="color: crimson"` + `class="ml-4"` still reach the svg (computed `color: rgb(220, 20, 60)`, `margin-left: 16px`)
- [x] Hover listeners still fire on the span wrapper (verified via dispatched `mouseenter`)
- [ ] Manual hover in a browser to confirm animations still play at the new size

🤖 Generated with [Claude Code](https://claude.com/claude-code)