### PR TITLE
fix(icons): facebook viewBox + remove smoke-test carve-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ docs-dist
 *.log
 .DS_Store
 .playwright-mcp
+test-results
+playwright-report
 .tmp-hero
 .tmp-social
 .tmp-closeup

--- a/scripts/port-pqoqubbw-icons.mjs
+++ b/scripts/port-pqoqubbw-icons.mjs
@@ -662,12 +662,21 @@ const selfWrap = computed(() => hasOwnTriggers(props))
  */
 function addVElse(svgJsx, kind) {
   const marker = '<motion.svg\n    v-else\n    overflow="visible"'
+  let out
   if (kind === 'motion-svg') {
-    return svgJsx.replace(/^<motion\.svg\b/, marker)
+    out = svgJsx.replace(/^<motion\.svg\b/, marker)
+  } else {
+    out = svgJsx
+      .replace(/^<svg\b/, marker)
+      .replace(/<\/svg>$/, '</motion.svg>')
   }
-  return svgJsx
-    .replace(/^<svg\b/, marker)
-    .replace(/<\/svg>$/, '</motion.svg>')
+  // Defensive: a handful of upstream icons (e.g. facebook) ship the svg
+  // tag without a viewBox. Without one the icon collapses to its native
+  // size and the smoke test's viewBox assertion (rightly) fails.
+  if (!/\bviewBox=/.test(out)) {
+    out = out.replace(/^<motion\.svg\b/, '<motion.svg\n    viewBox="0 0 24 24"')
+  }
+  return out
 }
 
 /**

--- a/src/icons/facebook.vue
+++ b/src/icons/facebook.vue
@@ -75,6 +75,7 @@ const selfWrap = computed(() => hasOwnTriggers(props))
           stroke-linecap="round"
           stroke-linejoin="round"
           :stroke-width="props.strokeWidth"
+          viewBox="0 0 24 24"
           :width="props.size"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/tests/unit/icons-smoke.spec.ts
+++ b/tests/unit/icons-smoke.spec.ts
@@ -25,12 +25,7 @@ describe('icons — smoke render', () => {
     expect(entries.length).toBeGreaterThan(500)
   })
 
-  // Icons whose template intentionally omits viewBox today. Tracked so the
-  // test still catches a *new* missing-viewBox regression introduced by the
-  // generator. Shrink this list as the underlying icons are fixed.
-  const KNOWN_NO_VIEWBOX = new Set(['facebook'])
-
-  it.each(entries)('$name renders an svg with a valid viewBox', ({ name, component }) => {
+  it.each(entries)('$name renders an svg with a valid viewBox', ({ component }) => {
     const wrapper = mount(component, {
       // No triggers: should render the bare <motion.svg> branch, not the
       // self-wrapped one. This is the most common consumer shape (icons
@@ -40,11 +35,9 @@ describe('icons — smoke render', () => {
     })
     const svg = wrapper.find('svg')
     expect(svg.exists()).toBe(true)
-    if (!KNOWN_NO_VIEWBOX.has(name)) {
-      // Most icons are 24×24; a handful (e.g. flask, syringe ported from
-      // upstream variants) use 512×512. Accept any zero-origin viewBox.
-      expect(svg.attributes('viewBox')).toMatch(/^0 0 \d+ \d+$/)
-    }
+    // Most icons are 24×24; a handful (e.g. flask, syringe ported from
+    // upstream variants) use 512×512. Accept any zero-origin viewBox.
+    expect(svg.attributes('viewBox')).toMatch(/^0 0 \d+ \d+$/)
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Summary
Stacked on top of #6. Once #6 lands, the base will be retargeted to `main` automatically.

- **Bug:** Upstream pqoqubbw ships facebook's `<svg>` without a `viewBox`. Without one the SVG uses `width`/`height` as the implicit user-coordinate space, so the path (coords 0–24) only renders correctly when `size` lands near 24. At `:size="48"` the icon paints at half-size anchored top-left; at 128 it shrinks to a corner glyph. Visually verified — see comment.
- **Fix:** Add `viewBox="0 0 24 24"` to `src/icons/facebook.vue`. Patch `scripts/port-pqoqubbw-icons.mjs` to inject `viewBox="0 0 24 24"` defensively when an upstream `<svg>` lacks one (so a future regen doesn't silently revert this).
- **Test cleanup:** drop the `KNOWN_NO_VIEWBOX = ['facebook']` carve-out in `tests/unit/icons-smoke.spec.ts` — the smoke test now passes for every icon.
- **Housekeeping:** gitignore `test-results/` and `playwright-report/`.

## Test plan
- [x] `pnpm test:unit` — 1631/1631 pass (carve-out removed, facebook now satisfies the assertion)
- [x] `pnpm typecheck` clean
- [x] Visual sanity check: rendered facebook at sizes 24 / 48 / 128 with vs. without viewBox; misalignment confirmed at 48+ without viewBox, fully fixed with it.